### PR TITLE
[18.0][IMP] sale_loyalty_order_line_link: add a related so button

### DIFF
--- a/sale_loyalty_order_line_link/README.rst
+++ b/sale_loyalty_order_line_link/README.rst
@@ -44,6 +44,9 @@ It also links the reward lines to:
   - In a product promo: the product lines over which the reward is
     discounted.
 
+Additionally, this module adds a button in the loyalty program form view
+to open related sale orders.
+
 **Table of contents**
 
 .. contents::

--- a/sale_loyalty_order_line_link/__manifest__.py
+++ b/sale_loyalty_order_line_link/__manifest__.py
@@ -12,5 +12,9 @@
     "maintainers": ["chienandalu"],
     "license": "AGPL-3",
     "depends": ["sale_loyalty"],
-    "data": ["reports/sale_report_views.xml", "views/sale_order_views.xml"],
+    "data": [
+        "reports/sale_report_views.xml",
+        "views/sale_order_views.xml",
+        "views/loyalty_program_views.xml",
+    ],
 }

--- a/sale_loyalty_order_line_link/models/__init__.py
+++ b/sale_loyalty_order_line_link/models/__init__.py
@@ -1,1 +1,1 @@
-from . import sale_order
+from . import loyalty_program, sale_order

--- a/sale_loyalty_order_line_link/models/loyalty_program.py
+++ b/sale_loyalty_order_line_link/models/loyalty_program.py
@@ -1,0 +1,19 @@
+from odoo import fields, models
+
+
+class LoyaltyProgram(models.Model):
+    _inherit = "loyalty.program"
+
+    related_so_count = fields.Integer(compute="_compute_related_so_count")
+
+    def _compute_related_so_count(self):
+        for program in self:
+            program.related_so_count = self.env["sale.order"].search_count(
+                [("order_line.loyalty_program_id", "=", program.id)]
+            )
+
+    def action_open_related_sale_orders(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id("sale.action_orders")
+        action["domain"] = [("order_line.loyalty_program_id", "=", self.id)]
+        return action

--- a/sale_loyalty_order_line_link/readme/DESCRIPTION.md
+++ b/sale_loyalty_order_line_link/readme/DESCRIPTION.md
@@ -11,3 +11,5 @@ It also links the reward lines to:
     whole order.
   - In a product promo: the product lines over which the reward is
     discounted.
+
+Additionally, this module adds a button in the loyalty program form view to open related sale orders.

--- a/sale_loyalty_order_line_link/static/description/index.html
+++ b/sale_loyalty_order_line_link/static/description/index.html
@@ -386,6 +386,8 @@ discounted.</li>
 </ul>
 </li>
 </ul>
+<p>Additionally, this module adds a button in the loyalty program form view
+to open related sale orders.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/sale_loyalty_order_line_link/views/loyalty_program_views.xml
+++ b/sale_loyalty_order_line_link/views/loyalty_program_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="loyalty_program_view_form_inherit" model="ir.ui.view">
+        <field name="name">loyalty.program.form.inherit</field>
+        <field name="model">loyalty.program</field>
+        <field name="inherit_id" ref="loyalty.loyalty_program_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_open_related_sale_orders"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-list-ul"
+                >
+                    <div class="o_form_field o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="related_so_count" />
+                        </span>
+                        <span class="o_stat_text">Related SO</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR adds a smart button in the loyalty program form view to open related sale orders, enhancing traceability and management of related sales

![image](https://github.com/user-attachments/assets/30f8e529-ed41-4759-ba09-9cab331ed72a)
